### PR TITLE
Set DB connection charset to utf8 everywhere

### DIFF
--- a/www/admin.php
+++ b/www/admin.php
@@ -1,6 +1,7 @@
 <?php
   include("header.php");
   $conn = mysqli_connect($host, $user, $password, "gsow", $port);
+  $conn->set_charset('utf8');
   $page = "";
   $dt = "YYYY-MM-DD";
   $act = "Add";

--- a/www/index.php
+++ b/www/index.php
@@ -11,7 +11,7 @@ Frozen Header
   error_reporting(-1);
   include("../config.php");
   $conn = mysqli_connect($host, $user, $password, "gsow", $port);
-	$conn->set_charset("utf8");
+  $conn->set_charset("utf8");
   $msg = "";
   if (isset($_POST['edit_id'])) {
     $q = "DELETE FROM edits where edit_id = " . $_POST['edit_id'] . " and lang='" . $_POST['lang'] . "'";

--- a/www/page-data.php
+++ b/www/page-data.php
@@ -1,6 +1,7 @@
 <?php
   include('../config.php');
   $conn = mysqli_connect($host, $user, $password, "gsow", $port);
+  $conn->set_charset('utf8');
   ini_set('display_errors',1);
   ini_set('display_startup_errors',1);
   error_reporting(-1);


### PR DESCRIPTION
This should address (or nearly address) the problem with page names that contain accented characters.